### PR TITLE
Fixed an error

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -117,8 +117,8 @@ Por exemplo, para criar uma imagem de dados binários retornados por uma requisi
 você pode usar o seguinte código:
 
     >>> from PIL import Image
-    >>> from StringIO import StringIO
-    >>> i = Image.open(StringIO(r.content))
+    >>> from io import BytesIO
+    >>> i = Image.open(BytesIO(r.content))
 
 
 Resposta JSON


### PR DESCRIPTION
If you use StringIO will get an error: initial_value must be str or None, not bytes.
The English version is BytesIO.
